### PR TITLE
Leak fix and two additional functions

### DIFF
--- a/protobuf-c-text/parse.re
+++ b/protobuf-c-text/parse.re
@@ -1296,3 +1296,21 @@ protobuf_c_text_from_string(const ProtobufCMessageDescriptor *descriptor,
   scanner_init_string(&scanner, msg);
   return protobuf_c_text_parse(descriptor, &scanner, result, allocator);
 }
+
+
+void
+protobuf_c_text_free_ProtobufCTextError(ProtobufCTextError *err){
+    if(err){
+        protobuf_c_text_free_ProtobufCTextError_data(err);
+        free(err);
+    }
+}
+
+void
+protobuf_c_text_free_ProtobufCTextError_data(ProtobufCTextError *err){
+    if(err){
+        free(err->error);
+        free(err->error_txt);
+    }
+}
+

--- a/protobuf-c-text/parse.re
+++ b/protobuf-c-text/parse.re
@@ -962,6 +962,13 @@ state_value(State *state, Token *t)
           return STATE_OPEN;
         } else {
           unsigned char *s;
+          unsigned char *old_ptr = STRUCT_MEMBER(unsigned char*, msg,
+                                                 state->field->offset);
+          if(old_ptr && old_ptr != state->field->default_value){
+             return state_error(state, t,
+                 "Field '%s' has already been assigned.",
+                 state->field->name);
+          }
 
           s = ST_ALLOC(t->qs->len + 1);
           if (!s) {

--- a/protobuf-c-text/protobuf-c-text.h
+++ b/protobuf-c-text/protobuf-c-text.h
@@ -130,6 +130,27 @@ typedef struct _ProtobufCTextError {
                          - >0: Message has all required fields set. */
 } ProtobufCTextError;
 
+/** Frees all provided buffers (error codes and error information) as well as the
+ * struct itself.
+ *
+ * This frees the entire ProtobufCTextError result which is returned when a parse
+ * fails.
+ *
+ * \param[in] The result / error message of a parse attempt
+ */
+extern void
+protobuf_c_text_free_ProtobufCTextError(ProtobufCTextError *err);
+
+/** Frees all internal data (error codes and error information), not the struct
+ *
+ * This frees the contents of the ProtobufCTextError result which is returned
+ * when a parse fails.
+ *
+ * \param[in] The result / error message of a parse attempt
+ */
+extern void
+protobuf_c_text_free_ProtobufCTextError_data(ProtobufCTextError *err);
+
 /** Convert a \c ProtobufCMessage to a string.
  *
  * Given a \c ProtobufCMessage serialise it as a text format protobuf.


### PR DESCRIPTION
The leak is due to a missing check: Strings that are not marked as optional or repeated should only be assigned once. 
In `protobuf-c-text/parse.re:967`, I added the check: I referenced code from similar checks in the previous lines 935-939.

The functions `protobuf_c_text_free_ProtobufCTextError_data` and `protobuf_c_text_free_ProtobufCTextError` are additions since error messages contain additional information for which the memory was allocated during the parsing process. The function initiating the parsing has to handle the error message and thus the memory if an error occurs. 