### PR TITLE
protobuf-c-text/generate.c: Make parameters const

### DIFF
--- a/protobuf-c-text/generate.c
+++ b/protobuf-c-text/generate.c
@@ -177,7 +177,7 @@ esc_str(unsigned char *src, int len, ProtobufCAllocator *allocator)
 static void
 protobuf_c_text_to_string_internal(ReturnString *rs,
     int level,
-    ProtobufCMessage *m,
+    const ProtobufCMessage *m,
     const ProtobufCMessageDescriptor *d,
     ProtobufCAllocator *allocator)
 {
@@ -499,7 +499,7 @@ protobuf_c_text_to_string_internal(ReturnString *rs,
 /* See .h file for API docs. */
 
 char *
-protobuf_c_text_to_string(ProtobufCMessage *m,
+protobuf_c_text_to_string(const ProtobufCMessage *m,
     ProtobufCAllocator *allocator)
 {
   ReturnString rs = { 0, 0, 0, NULL };

--- a/protobuf-c-text/protobuf-c-text.h
+++ b/protobuf-c-text/protobuf-c-text.h
@@ -170,7 +170,7 @@ protobuf_c_text_free_ProtobufCTextError_data(ProtobufCTextError *err);
  *         \endcode
  *         Though technically \c free(retval); is probably sufficient.
  */
-extern char *protobuf_c_text_to_string(ProtobufCMessage *m,
+extern char *protobuf_c_text_to_string(const ProtobufCMessage *m,
     ProtobufCAllocator *allocator);
 
 /** Import a text format protobuf from a string into a \c ProtobufCMessage.


### PR DESCRIPTION
This commit modifies the message parameter of protobuf_c_text_to_string as const s.t. library users can correctly pass structures marked as const.